### PR TITLE
Add correct twine API key

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -63,4 +63,4 @@ jobs:
     - uses: pypa/gh-action-pypi-publish@v1.5.0
       with:
         user: __token__
-        password: ${{ secrets.TWINE_API_KEY }}
+        password: ${{ secrets.BTB_UPLOAD_API_KEY }}


### PR DESCRIPTION
The API key has been created on PyPI and added to the repository actions secrets as `BTB_UPLOAD_API_KEY`.
The deployment workflow has been modified accordingly.