### PR TITLE
pin specific patch version for pypi upload action

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         name: artifact
         path: dist
-    - uses: pypa/gh-action-pypi-publish@v1.8
+    - uses: pypa/gh-action-pypi-publish@v1.8.11
       with:
         user: __token__
         password: ${{ secrets.BTB_UPLOAD_API_KEY }}


### PR DESCRIPTION
Because that action doesn't support specifying e.g. v1 or v1.8, we have to be specific - in this case v1.8.11 (the alternative is to depend on main/master).

See https://github.com/pypa/gh-action-pypi-publish/issues/22