### PR TITLE
implement dask-downsampling

### DIFF
--- a/brainglobe_template_builder/napari/_reader.py
+++ b/brainglobe_template_builder/napari/_reader.py
@@ -5,6 +5,7 @@ It implements the Reader specification, but your plugin may choose to
 implement multiple readers or even other plugin contributions. see:
 https://napari.org/stable/plugins/guides.html?#readers
 """
+
 from pathlib import Path
 
 from brainglobe_utils.IO.image.load import load_any

--- a/tests/test_unit/test_transform_utils.py
+++ b/tests/test_unit/test_transform_utils.py
@@ -1,0 +1,50 @@
+import dask.array as da
+import numpy as np
+import pytest
+from skimage import transform
+
+from brainglobe_template_builder.preproc.transform_utils import (
+    downsample_anisotropic_image_stack,
+)
+
+
+@pytest.fixture()
+def stack():
+    """Create a dask array representing an image stack"""
+    data = np.random.rand(10, 100, 100)  # Random image stack
+    return da.from_array(data, chunks=(1, 100, 100))
+
+
+@pytest.fixture()
+def not_slicewise_stack():
+    """Create a dask array representing an image stack"""
+    data = np.random.rand(10, 100, 100)  # Random image stack
+    return da.from_array(data, chunks=(2, 100, 100))
+
+
+def test_downsample_anisotropic_image_stack(stack):
+    """Test that downsampling with dask gives same as without."""
+    xy_downsampling = 20
+    z_downsampling = 2
+
+    downsampled_stack = downsample_anisotropic_image_stack(
+        stack, xy_downsampling, z_downsampling
+    )
+
+    assert downsampled_stack.shape == (5, 5, 5)
+
+    expected = transform.downscale_local_mean(
+        stack.compute(), (1, xy_downsampling, xy_downsampling)
+    )
+    expected = transform.downscale_local_mean(expected, (z_downsampling, 1, 1))
+    assert np.all(
+        downsampled_stack == expected
+    ), "dask downsampling does not match expected skimage result"
+
+
+def test_downsample_anisotropic_image_stack_raises(not_slicewise_stack):
+    with pytest.raises(AssertionError) as e:
+        downsample_anisotropic_image_stack(
+            not_slicewise_stack, xy_downsampling=20, z_downsampling=2
+        )
+    assert e.match("not chunked slice-wise!")


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

It's useful for at least the tadpole data (and hopefully many others) preprocessing to effectively downsample data, both for initial low-res atlases (for testing), and later higher-res production-ready atlases.

**What does this PR do?**

Adds a function to downsample an image in xy, and then z, with Dask.
This could be moved to utils, maybe, in a later step.

## References

\ 

## How has this PR been tested?

Simple tests added, trying not to over-engineer at this point in the package's history.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

Docstrings added. Documenting this package on a higher level is out-of-scope for this PR

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
