### PR TITLE
depend on latest brainglobe-utils

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 
 dependencies = [
     "napari[all]==0.4.19",
-    "brainglobe-utils>=0.5",
+    "brainglobe-utils>=0.6.2",
     "brainglobe-atlasapi>=2.0.7",
     "loguru",
     "antspyx",


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

We need `brainglobe-utils>=0.6.2` to read tadpole source data with `dask`

**What does this PR do?**
Enforces dependency on latest `brainglobe-utils`

## References

Closes #14 

## How has this PR been tested?

Local scripts reading tadpole data, to be added separately.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

