### PR TITLE
Fix transform bug

### DIFF
--- a/brainglobe_template_builder/preproc/transform_utils.py
+++ b/brainglobe_template_builder/preproc/transform_utils.py
@@ -67,8 +67,7 @@ def apply_transform(
 
     transformed = affine_transform(
         data,
-        np.linalg.inv(transform[:3, :3]),
-        offset=-transform[:3, 3],
+        np.linalg.inv(transform),
     )
     # Preserve original data range and type
     transformed = np.clip(transformed, data.min(), data.max())


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

There were some problems with the transformation in napari.

**What does this PR do?**

We pass the whole 4x4 matrix to scipy affine_transform, instead of splitting it into inv(3x3) and -translation.

## References

Closes #24 

## How has this PR been tested?

Manually on tadpole data, have opened #29 for improving test coverage.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [x] The code has been tested locally (manually)
- [ \ ] Tests have been added to cover all new functionality (unit & integration)
- [ \ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
