### PR TITLE
Constrain estimation of midplane points within mask extents

### DIFF
--- a/brainglobe_template_builder/preproc/transform_utils.py
+++ b/brainglobe_template_builder/preproc/transform_utils.py
@@ -53,7 +53,7 @@ def apply_transform(
 
     Notes
     -----
-    This function inverts the affine and flips the offset when passing the
+    This function inverts the affine and when passing the
     data to `scipy.ndimage.affine_transform`. This is because the
     transforms are given in the 'forward' direction, transforming input
     to output, whereas `scipy.ndimage.affine_transform` does 'backward'


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Fixes a bug in the estimation (initialisation) of midplane points that was noticed and discussed [here](https://github.com/brainglobe/brainglobe-template-builder/issues/24).

**What does this PR do?**
Adds an offset (minimum mask coordinate along each axis) that ensures the estimated points will always fall within the mask extents.

## References
#24 

## How has this PR been tested?

Manually, by ensuring that the failing example mentioned in the above issue now works.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
