### PR TITLE
Handle array data types prior to saving to nifti

### DIFF
--- a/brainglobe_template_builder/io.py
+++ b/brainglobe_template_builder/io.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from typing import Literal
 
 import nibabel as nib
 import numpy as np
@@ -79,7 +78,6 @@ def save_nii(
     stack: np.ndarray,
     vox_sizes: list,
     dest_path: Path,
-    kind: Literal["image", "label"] = "image",
 ):
     """
     Save 3D image stack to dest_path as a nifti image.
@@ -96,13 +94,7 @@ def save_nii(
         list of voxel dimensions in mm. The order is 'x', 'y', 'z'
     dest_path : pathlib.Path
         path to save the nifti image
-    kind : Literal["image", "label"]
-        Whether the stack is an image or a label. If label, the dtype
-        is converted to uint8.
     """
-    if kind == "label":
-        stack = stack.astype(np.uint8)
-
     affine = _get_transf_matrix_from_res(vox_sizes)
     nii_img = nib.Nifti1Image(stack, affine, dtype=stack.dtype)
     # Set qform and sform to match axes orientation, assuming ASR

--- a/brainglobe_template_builder/io.py
+++ b/brainglobe_template_builder/io.py
@@ -74,7 +74,7 @@ def save_3d_points_to_csv(points: np.ndarray, file_path: Path):
     points_df.to_csv(file_path, index=False)
 
 
-def save_nii(
+def save_as_asr_nii(
     stack: np.ndarray,
     vox_sizes: list,
     dest_path: Path,
@@ -180,7 +180,7 @@ def tiff_to_nifti(tiff_path: Path, nifti_path: Path, vox_sizes: list):
         list of voxel dimensions in mm. The order is 'x', 'y', 'z'
     """
     stack = load_any(tiff_path.as_posix())
-    save_nii(stack, vox_sizes, nifti_path)
+    save_as_asr_nii(stack, vox_sizes, nifti_path)
 
 
 def nifti_to_tiff(nifti_path: Path, tiff_path: Path):

--- a/brainglobe_template_builder/napari/save_widget.py
+++ b/brainglobe_template_builder/napari/save_widget.py
@@ -13,7 +13,10 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from brainglobe_template_builder.io import save_3d_points_to_csv, save_nii
+from brainglobe_template_builder.io import (
+    save_3d_points_to_csv,
+    save_as_asr_nii,
+)
 
 
 class SaveFiles(QWidget):
@@ -114,7 +117,7 @@ class SaveFiles(QWidget):
                 # native napari save to tif
                 layer.save(tif_path)
                 # save to nii
-                save_nii(
+                save_as_asr_nii(
                     layer.data,
                     vox_sizes=vox_sizes,
                     dest_path=nii_path,

--- a/brainglobe_template_builder/napari/save_widget.py
+++ b/brainglobe_template_builder/napari/save_widget.py
@@ -107,11 +107,14 @@ class SaveFiles(QWidget):
                 saved_layer_names.append(layer.name)
             elif isinstance(layer, Image) or isinstance(layer, Labels):
                 tif_path = f"{save_dir}/{layer.name}.tif"
-                if isinstance(layer, Image):
-                    layer.data = layer.data.astype("float32")
-                layer.save(tif_path)  # native napari save for images
                 nii_path = Path(f"{save_dir}/{layer.name}.nii.gz")
-                save_nii(  # custom save to nii
+                # choose array dtype based on layer type
+                dtype = "float32" if isinstance(layer, Image) else "uint8"
+                layer.data = layer.data.astype(dtype)
+                # native napari save to tif
+                layer.save(tif_path)
+                # save to nii
+                save_nii(
                     layer.data,
                     vox_sizes=vox_sizes,
                     dest_path=nii_path,

--- a/brainglobe_template_builder/preproc/alignment.py
+++ b/brainglobe_template_builder/preproc/alignment.py
@@ -219,11 +219,12 @@ class MidplaneAligner:
         np.ndarray
             An array of the same shape as the input image, with each half
             labelled with a different integer value (2 and 3).
+            The output data type is uint8.
         """
         axi = self.symmetry_axis_idx
         axis_len = image.shape[axi]
         half_len = axis_len // 2
-        labelled_halves = np.zeros_like(image, dtype=int)
+        labelled_halves = np.zeros_like(image, dtype=np.uint8)
 
         # Create slicing objects for each half
         slicer_half1 = [slice(None)] * image.ndim

--- a/brainglobe_template_builder/preproc/splitting.py
+++ b/brainglobe_template_builder/preproc/splitting.py
@@ -120,6 +120,8 @@ def save_array_dict_to_nii(
         A dictionary containing numpy arrays to save. The keys should be the
         filenames (without extension) and the values should be the arrays.
         If the arrays are masks, the keys should contain the string "mask".
+        Masks will be saved as uint8, while other arrays will be saved as
+        float32.
     save_dir : Path
         Directory to save the files to.
     vox_sizes : tuple
@@ -131,6 +133,7 @@ def save_array_dict_to_nii(
     for key, data in array_dict.items():
         file_path = save_dir / f"{key}.nii.gz"
         if "mask" in key:
-            save_nii(data, vox_sizes, file_path, kind="label")
+            data = data.astype("uint8")
         else:
-            save_nii(data, vox_sizes, file_path, kind="image")
+            data = data.astype("float32")
+        save_nii(data, vox_sizes, file_path)

--- a/brainglobe_template_builder/preproc/splitting.py
+++ b/brainglobe_template_builder/preproc/splitting.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import numpy as np
 
-from brainglobe_template_builder.io import save_nii
+from brainglobe_template_builder.io import save_as_asr_nii
 
 
 def get_right_and_left_slices(array: np.ndarray) -> tuple:
@@ -136,4 +136,4 @@ def save_array_dict_to_nii(
             data = data.astype("uint8")
         else:
             data = data.astype("float32")
-        save_nii(data, vox_sizes, file_path)
+        save_as_asr_nii(data, vox_sizes, file_path)

--- a/examples/BlackCap_post_build.py
+++ b/examples/BlackCap_post_build.py
@@ -92,7 +92,7 @@ logger.debug(f"Template zero-padded to shape: {template_padded.shape}.")
 # Save the padded template to the output directory
 # Henceforth we will refer to it as the atlas reference image.
 atlas_reference_file = output_dir / f"reference_{res_str}_image.nii.gz"
-save_nii(template_padded, vox_sizes, atlas_reference_file, kind="image")
+save_nii(template_padded, vox_sizes, atlas_reference_file)
 logger.debug(f"Saved atlas reference image as {atlas_reference_file.name}.")
 
 # Plot the atlas reference image to check

--- a/examples/BlackCap_post_build.py
+++ b/examples/BlackCap_post_build.py
@@ -22,7 +22,7 @@ import numpy as np
 from loguru import logger
 
 from brainglobe_template_builder.io import (
-    save_nii,
+    save_as_asr_nii,
 )
 from brainglobe_template_builder.preproc.masking import create_mask
 
@@ -92,7 +92,7 @@ logger.debug(f"Template zero-padded to shape: {template_padded.shape}.")
 # Save the padded template to the output directory
 # Henceforth we will refer to it as the atlas reference image.
 atlas_reference_file = output_dir / f"reference_{res_str}_image.nii.gz"
-save_nii(template_padded, vox_sizes, atlas_reference_file)
+save_as_asr_nii(template_padded, vox_sizes, atlas_reference_file)
 logger.debug(f"Saved atlas reference image as {atlas_reference_file.name}.")
 
 # Plot the atlas reference image to check

--- a/examples/BlackCap_prep_highres.py
+++ b/examples/BlackCap_prep_highres.py
@@ -30,7 +30,7 @@ from tqdm import tqdm
 from brainglobe_template_builder.io import (
     file_path_with_suffix,
     load_tiff,
-    save_nii,
+    save_as_asr_nii,
 )
 from brainglobe_template_builder.preproc.splitting import (
     generate_arrays_4template,
@@ -156,7 +156,7 @@ for idx, row in tqdm(df.iterrows(), total=n_subjects):
 
     # Save the reoriented image as nifti
     nii_path = deriv_subj_dir / f"{file_prefix}_orig-asr.nii.gz"
-    save_nii(image_asr, highres_vox_sizes, nii_path)
+    save_as_asr_nii(image_asr, highres_vox_sizes, nii_path)
     logger.debug(f"Saved reoriented image as {nii_path.name}.")
 
     # Bias field correction (to homogenise intensities)

--- a/examples/BlackCap_prep_highres.py
+++ b/examples/BlackCap_prep_highres.py
@@ -156,7 +156,7 @@ for idx, row in tqdm(df.iterrows(), total=n_subjects):
 
     # Save the reoriented image as nifti
     nii_path = deriv_subj_dir / f"{file_prefix}_orig-asr.nii.gz"
-    save_nii(image_asr, highres_vox_sizes, nii_path, kind="image")
+    save_nii(image_asr, highres_vox_sizes, nii_path)
     logger.debug(f"Saved reoriented image as {nii_path.name}.")
 
     # Bias field correction (to homogenise intensities)

--- a/examples/BlackCap_prep_lowres.py
+++ b/examples/BlackCap_prep_lowres.py
@@ -30,7 +30,7 @@ from tqdm import tqdm
 from brainglobe_template_builder.io import (
     file_path_with_suffix,
     load_tiff,
-    save_nii,
+    save_as_asr_nii,
 )
 from brainglobe_template_builder.preproc.masking import create_mask
 from brainglobe_template_builder.preproc.splitting import (
@@ -135,7 +135,7 @@ for idx, row in tqdm(df.iterrows(), total=n_subjects):
 
     # Save the reoriented image as nifti
     nii_path = file_path_with_suffix(tiff_path, "_orig-asr", new_ext=".nii.gz")
-    save_nii(image_asr, vox_sizes, nii_path)
+    save_as_asr_nii(image_asr, vox_sizes, nii_path)
     logger.debug(f"Saved reoriented image as {nii_path.name}.")
 
     # Bias field correction (to homogenise intensities)

--- a/examples/BlackCap_prep_lowres.py
+++ b/examples/BlackCap_prep_lowres.py
@@ -135,7 +135,7 @@ for idx, row in tqdm(df.iterrows(), total=n_subjects):
 
     # Save the reoriented image as nifti
     nii_path = file_path_with_suffix(tiff_path, "_orig-asr", new_ext=".nii.gz")
-    save_nii(image_asr, vox_sizes, nii_path, kind="image")
+    save_nii(image_asr, vox_sizes, nii_path)
     logger.debug(f"Saved reoriented image as {nii_path.name}.")
 
     # Bias field correction (to homogenise intensities)


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
The `save_nii` function accepts a `kind=Literal["image", "label"]` to specify whether the array being saved is an image or a label type (e.g. brain mask, region annotations). If `kind=="label"`, the dtype was converted to `uint8`, but if `kind=="image"` (the default), no conversion was made (aka the array dtype was maintained and saved to nifti as is).

This caused some problems:
- In some case, I forgot to pass the `kind="label"` argument, resulting in some labels saved with inappropriate datatypes.
- for images we had to handle the datatype prior to calling `save_nii`, while for labels this handling was left to `save_nii` itself (hence the confusing inconsistency).

**What does this PR do?**
Removes the `kind` kwarg from the `save_nii` functions. This means that any array datatype conversions have to be handled prior to saving the nifti. I also found all instances where `save_nii` was being called in the codebase, and made sure that the correct datatype was being passed to this functions. As part of this process, I discovered (and fixed) a bug where I was incorrectly creating an array with datatype `INT64`.

THe alternative would be to always handle datatype conversions within `save_nii`, and enforce `float32` for all images and `uint8` for all labels, but I thought that would be too restrictive.

## How has this PR been tested?

Manually, by going through the various widget functionalities.

## Is this a breaking change?
No.

## Does this PR require an update to the documentation?

n/a

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
