### PR TITLE
Fix license link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![License](https://img.shields.io/badge/License-BSD_3--Clause-orange.svg)](https://opensource.org/licenses/BSD-3-Clause)
+[![License](https://img.shields.io/badge/License-BSD_3--Clause-orange.svg)](https://opensource.org/license/bsd-3-clause/)
 ![CI](https://img.shields.io/github/actions/workflow/status/brainglobe/brainglobe-template-builder/test_and_deploy.yml?label=CI)
 [![codecov](https://codecov.io/gh/brainglobe/brainglobe-template-builder/branch/main/graph/badge.svg?token=P8CCH3TI8K)](https://codecov.io/gh/brainglobe/brainglobe-template-builder)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v0.json)](https://github.com/charliermarsh/ruff)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -85,6 +85,13 @@ exclude_patterns = [
     "**/includes/**",
 ]
 
+
+# A list of links (or regex) that match URIs that should not be checked
+# during sphinx-build linkcheck
+linkcheck_ignore = [
+    "https://opensource.org/license/*",  # to avoid odd 403 error
+]
+
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 html_theme = "pydata_sphinx_theme"


### PR DESCRIPTION
The open-source license website (as of few days ago) prevents linkcheck from verifying the url, which causes CI to fail. They only solution I've found is to ignore that domain during linkcheck,

For more info, see https://github.com/neuroinformatics-unit/movement/issues/324