### PR TITLE
Import Qt elements from qt-niu

### DIFF
--- a/brainglobe_template_builder/napari/_widget.py
+++ b/brainglobe_template_builder/napari/_widget.py
@@ -1,5 +1,5 @@
-from brainglobe_utils.qtpy.collapsible_widget import CollapsibleWidgetContainer
 from napari.viewer import Viewer
+from qt_niu.collapsible_widget import CollapsibleWidgetContainer
 
 from brainglobe_template_builder.napari.align_widget import AlignMidplane
 from brainglobe_template_builder.napari.mask_widget import CreateMask

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "brainglobe-atlasapi>=2.0.7",
     "loguru",
     "antspyx",
+    "qt-niu"
 ]
 
 entry-points."napari.manifest".brainglobe-template-builder = "brainglobe_template_builder.napari:napari.yaml"


### PR DESCRIPTION
Re-useable Qt elements have been moved from brainglobe-utils to [qt-niu](https://github.com/neuroinformatics-unit/qt-niu). This PR changes the imports accordingly.