### PR TITLE
depend on napari-medical-image-formats

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "napari[all]==0.4.19",
     "brainglobe-utils>=0.6.2",
     "brainglobe-atlasapi>=2.0.7",
+    "napari-medical-image-formats",
     "loguru",
     "antspyx",
     "qt-niu"


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Because we use ANTs under the hood, we often find ourselves working with nifti files when making templates. 

**What does this PR do?**
This allows us to look at niftis in `napari`, by adding a dependency on a nifti reader package

## How has this PR been tested?

Manual installation of `napari-medical-image-formats` and opening of a `.nii` file (note that `.nii.gz` not supported)
