### PR TITLE
remove setuptools_scm import

### DIFF
--- a/brainglobe_template_builder/napari/__init__.py
+++ b/brainglobe_template_builder/napari/__init__.py
@@ -1,11 +1,3 @@
-import setuptools_scm
-
-try:
-    release = setuptools_scm.get_version(root="../..", relative_to=__file__)
-    __version__ = release.split("+")[0]  # remove git hash
-except LookupError:
-    __version__ = "unknown"
-
 from brainglobe_template_builder.napari._reader import napari_get_reader
 from brainglobe_template_builder.napari._widget import PreprocWidgets
 


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Non-`[dev]` installation from `main` caused ModuleNotFoundError

**What does this PR do?**

Removes `scm` import from napari plugin folder `__init__.py` - unnecessary, and a relic from

## References

Please reference any existing issues/PRs that relate to this PR.

## How has this PR been tested?

I have tested manually that - in a clean `conda` env without `setuptools_scm` installed - I still get a sensible package version with `pip list | grep brainglobe-template-builder` and I can open the preprocessing widget.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

No

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
