### PR TITLE
Run scheduled tests again napari main

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -48,6 +48,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      # Run tests on napari main if this is a scheduled run
+      - name: Run tests on napari main
+        if: github.event_name == 'schedule'
+        uses: neuroinformatics-unit/actions/test@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+          tox-args: '-e napari-dev'
 
       - name: Notify slack on scheduled failure
         if: failure() && github.event_name == 'schedule'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ fix = true
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py{310,311,312}
+envlist = py{310,311,312}, napari-dev
 isolated_build = True
 
 [gh-actions]
@@ -117,4 +117,6 @@ extras =
     dev
 commands =
     pytest -v --color=yes --cov=brainglobe_template_builder --cov-report=xml
+deps =
+    napari-dev: git+https://github.com/napari/napari
 """


### PR DESCRIPTION
Adds an extra run of the neuroinformatics/actions/test with napari installed from main. This action will only run during the weekly cron job.