### PR TITLE
Add alternative to ants.plot

### DIFF
--- a/brainglobe_template_builder/plots.py
+++ b/brainglobe_template_builder/plots.py
@@ -306,6 +306,9 @@ def _set_imshow_defaults(
     kwargs.setdefault("aspect", "equal")
 
     if not adjust_contrast:
+        # remove vmin / max if present
+        kwargs.pop("vmin", None)
+        kwargs.pop("vmax", None)
         return kwargs
 
     missing_keys = [key for key in ("vmin", "vmax") if key not in kwargs]


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [X] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
This PR adds an alternative to `ants.plot`, which is difficult to run locally on Windows.

**What does this PR do?**

Expands the existing `plot_grid` function to add the following features:
- image overlays (must be same dimensions as `img`)
- overlay display settings e.g. alpha + cmap
- custom plot title
- clipping of dark slices near the start / end of the volume (otherwise I was seeing multiple black images in the grid from empty areas in front of the brain)

I've tried to cover the two common use cases for `ants.plot` mainly:
- overlaying a mask / segmentation over a brain image
- overlaying one brain image over another (e.g. to check registration accuracy)

If there are more features needed - then do let me know!

## References

For https://github.com/brainglobe/brainglobe-template-builder/issues/93

## How has this PR been tested?

I ran the old `ants` workflow for the two main use cases:

```
# mask overlay
ants.plot(
    image,
    mask,
    overlay_alpha=0.5,
    axis=1,
    title="Brain mask over image",
    filename="path/to/output.png",
)

# image on image overlay
ants.plot(
    image_one,
    image_two,
    overlay_alpha=0.5,
    axis=1,
    overlay_cmap="plasma",
    title="Registered images",
    filename="path/to/output.png",
)
```

and compared to the new method:

```
# mask overlay
plot_grid(
   input_numpy, 
   overlay=mask_numpy, 
   overlay_is_mask=True, 
   plot_title="Brain mask over image", 
   section="frontal", 
   save_path=Path(r"path/to/output.png")
)

# image on image overlay
plot_grid(
    input_numpy, 
    overlay=image_two_numpy,
    section="frontal", 
    save_path=Path(r"path/to/output.png")
)
```
The results are in the `sub-ZF65f` `derivatives` folder. For the image-on-image overlays I created a variant of `sub-ZF65f_channel-green_res-25x25x25um_origin-asr_N4.nii.gz` that was slightly displaced - saved in the same dir called: `sub-ZF65f_channel-green_res-50x50x50um_origin-asr_TEMP-displaced.nii.gz`. The ants outputs have `TEMP-ants...` in their suffix, while the new matplotlib outputs have `TEMP-matplotlib...`.

Some comparison images:
| ANTS | Matplotlib |
|------------|------------------------------|
| <img width="1000" alt="sub-ZF65f_channel-green_res-50x50x50um_origin-asr-TEMP-ants-mask-overlay" src="https://github.com/user-attachments/assets/577a6537-eeb5-4764-a935-c5a735cdc44b" /> | <img width="1000" alt="sub-ZF65f_channel-green_res-50x50x50um_origin-asr-TEMP-matplotlib-mask-overlay" src="https://github.com/user-attachments/assets/0d5d4316-c3d0-42f8-b562-339e18b49d57" /> |
| <img width="1000" alt="sub-ZF65f_channel-green_res-50x50x50um_origin-asr-TEMP-ants-registered-overlay" src="https://github.com/user-attachments/assets/0c48c23f-6ba0-456b-a0b5-3cd396415633" /> | <img width="1000" alt="sub-ZF65f_channel-green_res-50x50x50um_origin-asr_TEMP-matplotlib-registered-overlay" src="https://github.com/user-attachments/assets/b9a11ddd-8869-474e-a9b2-b3d1cfc18705" /> |


## Is this a breaking change?

No

## Does this PR require an update to the documentation?

I've updated the relevant docstrings, but I guess full user docs will come once more of the pipeline is in place.

## Checklist:

- [X] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [X] The code has been formatted with [pre-commit](https://pre-commit.com/)
