### PR TITLE
Relax tolerence in test_correct_image_brightness and use assert_allclose

### DIFF
--- a/tests/test_unit/test_brightness.py
+++ b/tests/test_unit/test_brightness.py
@@ -18,9 +18,6 @@ def test_correct_image_brightness():
     ants_corrected_image = load_any(corrected_image_path())
 
     assert output_image.shape == ants_corrected_image.shape
-    # Check largest pixel value difference between ants correction and
-    # our own is 0.04
-    # Note: the github actions windows runner needs this higher 0.04
-    # threshold, but all others (as well as running locally on a windows
-    # computer), can use a tighter 0.01 threshold
-    assert np.absolute(ants_corrected_image - output_image).max() < 0.04
+    # Note: max difference values can differ slightly across platforms, but
+    # the max relative difference should be below 1E-3 in all cases.
+    np.testing.assert_allclose(output_image, ants_corrected_image, rtol=1e-03)


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Tests were failing depending on how they were run.

**What does this PR do?**
Relaxes tolerence used for max difference between ants_corrected and new output images in `test_correct_image_brightness`.

## References
Resolves #102 


## How has this PR been tested?

Please explain how any new code has been tested, and how you have ensured that no existing functionality has changed.

## Is this a breaking change?
Nope

## Does this PR require an update to the documentation?
I updated the note to:

> ```
>     # Note: max difference values can differ slightly across platforms, but
>     # the max relative difference should be below 1E-3 in all cases.
> ```

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
