### PR TITLE
remove references to x, y, z for save_as_asr_nii

### DIFF
--- a/brainglobe_template_builder/io.py
+++ b/brainglobe_template_builder/io.py
@@ -117,7 +117,7 @@ def tiff_to_nifti(tiff_path: Path, nifti_path: Path, vox_sizes: list):
     nifti_path : pathlib.Path
         path to save the nifti image
     vox_sizes : list
-        list of voxel dimensions in mm. The order is 'x', 'y', 'z'
+        list of voxel dimensions in mm, in the same order as the image axes.
     """
     stack = load_any(tiff_path.as_posix())
     save_as_asr_nii(stack, vox_sizes, nifti_path)


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [X] Other

**Why is this PR needed?**
[As discussed on the `raw_to_ready` PR](https://github.com/brainglobe/brainglobe-template-builder/pull/97#discussion_r2588536556), `save_as_asr_nii` needs voxel dimensions given in the same order as the stack axes. We should remove any references to needing x/y/z.

**What does this PR do?**
Very small change - to remove one reference to `xyz` in a function that uses `save_as_asr_nii`. I was going to update `source_to_raw` also, but turns out it isn't necessary as it always assumes an isotropic output:
```
output_vox_sizes = [output_vox_size, output_vox_size, output_vox_size]
vox_sizes_mm = [vox_size * 0.001 for vox_size in output_vox_sizes]
save_as_asr_nii(image, vox_sizes=vox_sizes_mm, dest_path=output_path)
```

## References

Discussed on https://github.com/brainglobe/brainglobe-template-builder/pull/97

## How has this PR been tested?

N/A

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [X] The code has been tested locally
- [X] Tests have been added to cover all new functionality (unit & integration)
- [X] The documentation has been updated to reflect any changes
- [X] The code has been formatted with [pre-commit](https://pre-commit.com/)
