### PR TITLE
use np.testing.assert_allclose for zoom comparisons in test_standardise

### DIFF
--- a/tests/test_unit/test_standardise.py
+++ b/tests/test_unit/test_standardise.py
@@ -425,7 +425,7 @@ def test_standardise_downsampling(request, source_csv, expected_output_size):
     image_path = subject_dir / "sub-b_res-20x20x20um_origin-asr.nii.gz"
     mask_path = subject_dir / "sub-b_res-20x20x20um_mask_origin-asr.nii.gz"
 
-    expected_output_vox_sizes_mm = (
+    output_vox_sizes_mm = (
         output_vox_size * 0.001,
         output_vox_size * 0.001,
         output_vox_size * 0.001,
@@ -434,6 +434,6 @@ def test_standardise_downsampling(request, source_csv, expected_output_size):
     for output_path in [image_path, mask_path]:
         image = load_nii(output_path, as_array=False)
         np.testing.assert_allclose(
-            image.header.get_zooms(), expected_output_vox_sizes_mm
+            image.header.get_zooms(), output_vox_sizes_mm
         )
         assert image.shape == expected_output_size


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Some tests that are not supposed to fail are failing.

**What does this PR do?**
Uses `np.allclose` to compare i`mage.header.get_zooms()` values against expected values.

## References
Resolves #117 

## How has this PR been tested?
Ran the test locally using `pytest` from the terminal, now the previously failing tests are passing.

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
No

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
