### PR TITLE
Allow PreprocConfig input to `preprocess`

### DIFF
--- a/tests/test_unit/test_preprocess.py
+++ b/tests/test_unit/test_preprocess.py
@@ -175,10 +175,25 @@ def test_preprocess_use_input(
     )
 
 
-def test_preprocess(create_standardised_test_data: tuple[Path, Path]) -> None:
-    """Test that preprocess creates expected directories and files."""
+@pytest.mark.parametrize(
+    "config_type",
+    ["config_file", "PreprocConfig object"],
+)
+def test_preprocess(
+    create_standardised_test_data: tuple[Path, Path], config_type: str
+) -> None:
+    """Test that preprocess creates expected directories and files - both
+    with a config yaml file path as input OR a PreprocConfig object."""
     csv_path, config_path = create_standardised_test_data
-    preprocess(csv_path, config_path)
+
+    if config_type == "config_file":
+        config = config_path
+    else:
+        with open(config_path) as f:
+            config_yaml = yaml.safe_load(f)
+        config = PreprocConfig.model_validate(config_yaml)
+
+    preprocess(csv_path, config=config)
 
     preprocessed_dir = csv_path.parents[1] / "preprocessed"
     qc_dir = csv_path.parents[1] / "preprocessed-QC"


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [X] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Previously, `preprocess` could only accept a path to a config yaml file - as explained on https://github.com/brainglobe/brainglobe-template-builder/issues/122, it would be useful to support `PreprocConfig` objects directly also.

**What does this PR do?**
Adds support for passing `PreprocConfig` objects directly to `preprocess`

## References

Closes https://github.com/brainglobe/brainglobe-template-builder/issues/122

## How has this PR been tested?

The test for `preprocess` directory structure has been updated to use both a config yaml file path + a direct `PreprocConfig` object.

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

Relevant docstrings have been updated.

## Checklist:

- [X] The code has been tested locally
- [X] Tests have been added to cover all new functionality (unit & integration)
- [X] The documentation has been updated to reflect any changes
- [X] The code has been formatted with [pre-commit](https://pre-commit.com/)
