### PR TITLE
Remove parentheses from fixture decorators

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,7 +108,7 @@ def _create_test_yaml(path: Path) -> Path:
     return config_path
 
 
-@pytest.fixture()
+@pytest.fixture
 def write_test_data() -> Callable:
     """Callable fixture for writing test data files."""
 
@@ -130,7 +130,7 @@ def write_test_data() -> Callable:
     return _write_test_data
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_fancylog_datetime(mocker):
     """Mock datetime.now for fancylog to 2025-12-10 15:15.
 
@@ -143,7 +143,7 @@ def mock_fancylog_datetime(mocker):
     )
 
 
-@pytest.fixture()
+@pytest.fixture
 def test_stacks() -> dict[str, NDArray[np.float64]]:
     """Create symmetric and asymmetric test images and masks."""
     return {
@@ -152,7 +152,7 @@ def test_stacks() -> dict[str, NDArray[np.float64]]:
     }
 
 
-@pytest.fixture()
+@pytest.fixture
 def test_data(
     test_stacks: dict[str, NDArray[np.float64]],
 ) -> list[dict[str, Any]]:
@@ -175,8 +175,8 @@ def test_data(
     ]
 
 
-@pytest.fixture()
-def make_tmp_dir(tmp_path: Path):
+@pytest.fixture
+def make_tmp_dir(tmp_path: Path) -> Callable:
     """Callable that creates a subdirectory under tmp_path."""
 
     def _make_subdir(name: str) -> Path:

--- a/tests/test_unit/test_preprocess.py
+++ b/tests/test_unit/test_preprocess.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 import numpy as np
 import pandas as pd
@@ -19,11 +19,11 @@ from brainglobe_template_builder.preprocess import (
 from brainglobe_template_builder.utils.preproc_config import PreprocConfig
 
 
-@pytest.fixture()
+@pytest.fixture
 def write_standardised_test_data(
     test_data: list[dict[str, Any]],
-    make_tmp_dir,
-    write_test_data,
+    make_tmp_dir: Callable,
+    write_test_data: Callable,
 ) -> tuple[Path, Path] | Path:
     """Create standardised test data with CSV and config."""
 

--- a/tests/test_unit/test_standardise.py
+++ b/tests/test_unit/test_standardise.py
@@ -11,7 +11,7 @@ from numpy._typing._array_like import NDArray
 from brainglobe_template_builder.standardise import standardise
 
 
-@pytest.fixture()
+@pytest.fixture
 def source_dir(
     make_tmp_dir: Callable[[str], Path],
 ) -> tuple[Path, Path] | Path:
@@ -19,8 +19,8 @@ def source_dir(
     return make_tmp_dir("source")
 
 
-@pytest.fixture()
-def source_data_kwargs(make_tmp_dir, test_data):
+@pytest.fixture
+def source_data_kwargs(make_tmp_dir: Callable, test_data: list[dict]) -> dict:
     return {
         "image_type": "tif",
         "csv_name": "source_data",
@@ -30,7 +30,7 @@ def source_data_kwargs(make_tmp_dir, test_data):
     }
 
 
-@pytest.fixture()
+@pytest.fixture
 def source_csv_no_masks(
     write_test_data: Callable, source_data_kwargs: dict
 ) -> tuple[Path, Path] | Path:
@@ -38,7 +38,7 @@ def source_csv_no_masks(
     return write_test_data(**source_data_kwargs)
 
 
-@pytest.fixture()
+@pytest.fixture
 def source_csv_with_masks(
     source_data_kwargs: dict[str, Any],
     test_stacks: dict[str, NDArray[np.float64]],
@@ -53,7 +53,7 @@ def source_csv_with_masks(
     return write_test_data(**source_data_kwargs)
 
 
-@pytest.fixture()
+@pytest.fixture
 def source_csv_single_image_with_mask(
     source_data_kwargs: dict[str, Any],
     test_stacks: dict[str, NDArray[np.float64]],
@@ -68,7 +68,7 @@ def source_csv_single_image_with_mask(
     return write_test_data(**source_data_kwargs)
 
 
-@pytest.fixture()
+@pytest.fixture
 def source_csv_with_use(
     source_data_kwargs: dict[str, Any], write_test_data: Callable
 ) -> tuple[Path, Path] | Path:
@@ -81,7 +81,7 @@ def source_csv_with_use(
     return write_test_data(**source_data_kwargs)
 
 
-@pytest.fixture()
+@pytest.fixture
 def source_csv_anisotropic_with_mask(
     source_data_kwargs: dict[str, Any],
     test_stacks: dict[str, NDArray[np.float64]],

--- a/tests/test_unit/test_transform_utils.py
+++ b/tests/test_unit/test_transform_utils.py
@@ -8,7 +8,7 @@ from brainglobe_template_builder.utils.transform_utils import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def stack():
     """Create a dask array representing an image stack"""
     rng = np.random.default_rng()
@@ -16,7 +16,7 @@ def stack():
     return da.from_array(data, chunks=(1, 100, 100))
 
 
-@pytest.fixture()
+@pytest.fixture
 def mask():
     """Create a dask array representing a mask - only values 0 and 1."""
     data = np.zeros(shape=(10, 100, 100), dtype="float64")
@@ -24,14 +24,14 @@ def mask():
     return da.from_array(data, chunks=(1, 100, 100))
 
 
-@pytest.fixture()
+@pytest.fixture
 def not_slicewise_stack(stack):
     """Create a dask array representing an image stack,
     chunked by multiple slices."""
     return stack.rechunk({0: 2, 1: 100, 2: 100})
 
 
-@pytest.fixture()
+@pytest.fixture
 def partial_slicewise_stack(stack):
     """Create a dask array representing an image stack,
     chunked by part of an individual slice."""


### PR DESCRIPTION
## Description
Closing this PR and starting a fresh one.

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
Best practice to not use parentheses when we don't pass arguments (realised this after #120 was merged).

**What does this PR do?**
- removes parentheses from fixture decorators when no arguments are passed.
- adds typing in a few places where I forgot to add it in PR #120 

## References
/

## How has this PR been tested?
/ 

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
Nope

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
