### PR TITLE
Bug fix: remove edge_width attribute from align widget

### DIFF
--- a/brainglobe_template_builder/napari/align_widget.py
+++ b/brainglobe_template_builder/napari/align_widget.py
@@ -145,6 +145,7 @@ class AlignMidplane(QWidget):
             "properties": {"label": list(range(9))},
             "face_color": "green",
             "symbol": "cross",
+            "border_width": 0,
             "opacity": 0.6,
             "size": 6,
             "ndim": mask.ndim,


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

The `AlignMidplane` widget uses the deprecated `edge_width` property when creating Points layers. In napari 0.5.0, this property was renamed to `border_width`, causing the widget to fail.

From the [napari Points layer documentation](https://napari.org/stable/howtos/layers/points.html):

> As of napari 0.5.0, `edge_*` attributes are being renamed to `border_*` attributes.

**What does this PR do?**

Replaces `edge_width` with `border_width` in `align_widget.py` to fix compatibility with napari 0.5.0+.

## References
Bug found while working on #152 (issue #143)

## How has this PR been tested?
Tested by (currently `xfail` marked) `test_estimate_points` in PR #152 

## Is this a breaking change?
No. 

## Does this PR require an update to the documentation?
I don't think so.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration) (will be in PR #152)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)