### PR TITLE
Bug fix: Ensure MidplaneEstimator get_points inserts axis coordinates in correct order

### DIFF
--- a/brainglobe_template_builder/utils/alignment.py
+++ b/brainglobe_template_builder/utils/alignment.py
@@ -69,7 +69,7 @@ class MidplaneEstimator:
 
         self._get_mask_properties()
         # Find middle of the symmetry axis
-        mid_plane = self.centroid[self.symmetry_axis_idx]
+        mid_symmetry_axis = self.centroid[self.symmetry_axis_idx]
         # Find slices at 1/4, 2/4, and 3/4 of the mask extents along the
         # other two (non-symmetry) axes
         a, b = [i for i in range(3) if i != self.symmetry_axis_idx]
@@ -80,10 +80,20 @@ class MidplaneEstimator:
         other_planes_b = [
             self.bbox[b, 0] + mask_extents[b] / 4 * i for i in [1, 2, 3]
         ]
-        # Find points at the intersection the symmetry axis midplane
-        # with quarter-planes of the other two axes (produces 9 points)
-        points = list(product(other_planes_a, other_planes_b, [mid_plane]))
-        self.points = np.array(points)  # (9, 3)
+
+        # Create 9 points by combining all pairs of coordinates from axes a and
+        # b, keeping the symmetry axis at its midpoint.
+        points = []
+        for coor_axis_a, coor_axis_b in product(
+            other_planes_a, other_planes_b
+        ):
+            point = np.zeros(3)
+            point[self.symmetry_axis_idx] = mid_symmetry_axis
+            point[a] = coor_axis_a
+            point[b] = coor_axis_b
+            points.append(point)
+
+        self.points = np.array(points)
         return self.points
 
 


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
`Align midplane` point estimates for Y and Z symmetry axes using the napari `align midplane` widget are not as expected (see description in #160)

**What does this PR do?**
Ensures that axis coordinates are inserted in the right order (depending on which symmetry axis is picked).

## References
Resolves #160 

## How has this PR been tested?
`test_estimate_points_symmetry_axis` (see PR #152) to check whether the point coordinates on the right axis stay stable.

I also checked the behaviour of the napari widget by
- Opening Allen mouse (25 um) Atlas using `brainrender` plugin in napari and create a mask.
- Use mask to estimate points along X, Y, and Z midplanes using the `Align mideplane` widget in `Preprocess` (`brainglobe-template-builder` plugin)

Estimated points across midplanes using X, Y, Z symmetry axes:
- X: Green crosses
- Y: Pink stars
- Z: Blue diamants

### Before fix
<img width="350" alt="Image" src="https://github.com/user-attachments/assets/b59f3247-21d3-42ce-9846-6148ecd3a65a" />

<img width="350" alt="Image" src="https://github.com/user-attachments/assets/5a464135-5578-4c17-9ad9-dcda226c5b66" />


### After fix
<img width="350" alt="saggital_points" src="https://github.com/user-attachments/assets/b3f2a7ec-4541-46a9-a7c1-a84ae682a92c" />
<img width="350"  alt="coronal_points" src="https://github.com/user-attachments/assets/808168e4-a26b-4847-b5fc-7e14f4b7ea2f" />
<img width="350"  alt="horizontal_points" src="https://github.com/user-attachments/assets/6da5459e-e96e-4eb0-b16e-3a208bf53750" />



## Is this a breaking change?
No

## Does this PR require an update to the documentation?
Nope

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
