### PR TITLE
Return identity matrix if vec1 and vec2 point in same or opposite directions in 

### DIFF
--- a/brainglobe_template_builder/utils/transform_utils.py
+++ b/brainglobe_template_builder/utils/transform_utils.py
@@ -23,10 +23,9 @@ def get_rotation_from_vectors(vec1: np.ndarray, vec2: np.ndarray):
 
     Returns
     -------
-    np.ndarray
-        A rotation matrix (3x3) that, when applied to vec1, aligns it with
-        vec2. When vec1 and vec2 point in the same or opposite directions and
-        no rotation is needed, the rotation matrix is an identity matrix.
+    A rotation matrix (3x3) that, when applied to vec1, aligns it with
+    vec2. When vec1 and vec2 point in the same or opposite directions and
+    no rotation is needed, the rotation matrix is an identity matrix.
 
     References
     ----------


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
`get_rotation_from_vectors` does not handle situations in which no rotation is needed (i.e. the directions of `vec1` and `vec2` are the same or exactly oposite). In these cases, both `(1 - c)` and `(s**2)` become zero, and the rotation_matrix (`np.eye(3) + kmat + kmat.dot(kmat) * ((1 - c) / (s**2))`) will be filled with `NaN`s, subsequently resulting in the `NaN` filled transformation matrix (described in issue #155)

**What does this PR do?**
Adds check to `get_rotation_from_vectors` to determine whether the normalized vectors (`a` and `b`) point in the same or exactly opposite direction and returns the identity matrix if this is the case.
```
    # If vec1 and vec2 are already aligned, return identity matrix
    if np.isclose(np.abs(np.dot(a, b)), 1.0):
        return np.eye(3)
```

## References
Resolves #155 

## How has this PR been tested?
`test_align_midplane` see PR #152 tests whether midplane can be aligned without raising an exception. Two scenarios have been tested: when rotation is needed (by adding offset to the by default perfectly aligned points), and when it is not (this currently fails but will pass with the fix in this PR).

## Is this a breaking change?
No

## Does this PR require an update to the documentation?
I've added a note to the docstring about the rotation matrix return to reflect the update

> When vec1 and vec2 point in the same or opposite directions and no rotation is needed, the rotation matrix is an identity matrix.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
