### PR TITLE
Update validation and conversion to bool for masks

### DIFF
--- a/brainglobe_template_builder/utils/alignment.py
+++ b/brainglobe_template_builder/utils/alignment.py
@@ -1,3 +1,4 @@
+import warnings
 from itertools import product
 from pathlib import Path
 from typing import Literal
@@ -41,15 +42,23 @@ class MidplaneEstimator:
 
     def _validate_inputs(self):
         """Validate the inputs to the aligner."""
-
         if self.mask.ndim != 3:
             raise ValueError("Mask must be 3D")
         if self.symmetry_axis not in ["x", "y", "z"]:
             raise ValueError("Symmetry axis must be one of 'x', 'y', or 'z'")
-        try:
+        unique_values = set(np.unique(self.mask))
+        if 0 not in unique_values:
+            raise ValueError("Mask must contain zero values (background)")
+        if unique_values == {0}:
+            raise ValueError("Mask must contain nonzero values (object)")
+        if len(unique_values) > 2:
+            warnings.warn(
+                f"Mask is not binary ({len(unique_values)} unique values). "
+                "Converting: all nonzero values to True (object), and all "
+                "zero values to False (background)."
+            )
+        if len(unique_values) > 1:
             self.mask = self.mask.astype(bool)
-        except ValueError:
-            raise ValueError("Mask must be binary")
 
     def _get_mask_properties(self):
         """Get properties of the mask, specifically the centroid and the


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Mask validation was not working as expected (silently converting non binary masks to `bool`s)

**What does this PR do?**
Instead of the `try` block:
- `ValueError` if mask includes not at least one background zero value
- `ValueError` if mask includes not at least one non‑zero value (an object)
- `Warning` if mask isn’t binary and will be converted 

If the mask has zero and non‑zero values, convert it to a boolean mask where non‑zero becomes `True`.

## References
Closes #167 
#170 added tests should be adapted (and `pytest.skip` marker removed) for relevant tests.

## How has this PR been tested?
Tests added in #170 will have to be adapted.

## Is this a breaking change?
No.

## Does this PR require an update to the documentation?

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration) (#170)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
