### PR TITLE
Make template building HPC job more configurable

### DIFF
--- a/brainglobe_template_builder/preprocess.py
+++ b/brainglobe_template_builder/preprocess.py
@@ -18,7 +18,10 @@ from brainglobe_template_builder.utils.brightness import (
 )
 from brainglobe_template_builder.utils.cropping import crop_to_mask
 from brainglobe_template_builder.utils.masking import create_mask
-from brainglobe_template_builder.utils.preproc_config import PreprocConfig
+from brainglobe_template_builder.utils.preproc_config import (
+    MaskConfig,
+    PreprocConfig,
+)
 from brainglobe_template_builder.validate import validate_input_csv
 
 logger = logging.getLogger(__name__)
@@ -158,7 +161,9 @@ def _process_subject(
     }
 
 
-def preprocess(standardised_csv: Path, config: Path | PreprocConfig) -> None:
+def preprocess(
+    standardised_csv: Path, config: Path | PreprocConfig | None = None
+) -> None:
     """Process nifti files in ASR orientation to create output images +
     masks ready for template creation.
 
@@ -189,12 +194,19 @@ def preprocess(standardised_csv: Path, config: Path | PreprocConfig) -> None:
     standardised_csv : Path
         Standardised csv file path. One row per sample, each with a
         unique 'subject_id' - this is created via `standardise`.
-    config : Path | PreprocConfig
+    config : Path | PreprocConfig | None
         Config yaml file path, or PreprocConfig object. Contains settings for
-        pre-processing steps.
+        pre-processing steps. Defaults to None, which will use defaults.
     """
 
-    if isinstance(config, Path):
+    if not config:
+        # use default mask and padding, and default to outputting
+        # into sibling folder of `standardised/`
+        config = PreprocConfig(
+            output_dir=standardised_csv.parent.parent / "preprocessed",
+            mask=MaskConfig(),
+        )
+    elif isinstance(config, Path):
         with open(config) as f:
             config_yaml = yaml.safe_load(f)
         preproc_config = PreprocConfig.model_validate(config_yaml)

--- a/brainglobe_template_builder/preprocess.py
+++ b/brainglobe_template_builder/preprocess.py
@@ -77,6 +77,9 @@ def _process_subject(
 ) -> dict[str, Path]:
     """Process an individual subject's images.
 
+    Creates the mask based on the image and the config parameter
+    before applying the brightness correction step.
+
     Parameters
     ----------
     subject_row : pd.Series
@@ -231,7 +234,7 @@ def preprocess(standardised_csv: Path, config: Path | PreprocConfig) -> None:
         total_subjects -= input_df.use.value_counts().get(False, 0)
     pbar = tqdm(
         total=total_subjects,
-        desc="Brightness correction and mask creation",
+        desc="Mask creation and brightness correction",
         unit="subject",
     )
 

--- a/brainglobe_template_builder/preprocess.py
+++ b/brainglobe_template_builder/preprocess.py
@@ -108,9 +108,6 @@ def _process_subject(
         subject_row.resolution_2 * 0.001,
     ]
 
-    # n4 bias field correction
-    image = correct_image_brightness(image, spacing=vox_sizes_mm)
-
     if ("mask_filepath" in subject_row) and pd.notna(
         subject_row.mask_filepath
     ):
@@ -125,6 +122,9 @@ def _process_subject(
             closing_size=mask_config.closing_size,
             erode_size=mask_config.erode_size,
         )
+
+    # n4 bias field correction
+    image = correct_image_brightness(image, spacing=vox_sizes_mm)
 
     # Crop image to mask bounds, and pad by n pixels
     image, mask = crop_to_mask(image, mask, padding=config.pad_pixels)

--- a/brainglobe_template_builder/preprocess.py
+++ b/brainglobe_template_builder/preprocess.py
@@ -202,8 +202,8 @@ def preprocess(
     if not config:
         # use default mask and padding, and default to outputting
         # into sibling folder of `standardised/`
-        config = PreprocConfig(
-            output_dir=standardised_csv.parent.parent / "preprocessed",
+        preproc_config = PreprocConfig(
+            output_dir=standardised_csv.parent.parent,
             mask=MaskConfig(),
         )
     elif isinstance(config, Path):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -90,6 +90,8 @@ exclude_patterns = [
 # during sphinx-build linkcheck
 linkcheck_ignore = [
     "https://opensource.org/license/*",  # to avoid odd 403 error
+    "https://zenodo.org/badge/*"  # to avoid 403 error
+    "https://doi.org"  # avoid 403 error
     "https://biorxiv.org",  # Read time outs
 ]
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -90,6 +90,7 @@ exclude_patterns = [
 # during sphinx-build linkcheck
 linkcheck_ignore = [
     "https://opensource.org/license/*",  # to avoid odd 403 error
+    "https://biorxiv.org",  # Read time outs
 ]
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -90,9 +90,8 @@ exclude_patterns = [
 # during sphinx-build linkcheck
 linkcheck_ignore = [
     "https://opensource.org/license/*",  # to avoid odd 403 error
-    "https://zenodo.org/badge/*"  # to avoid 403 error
-    "https://doi.org"  # avoid 403 error
-    "https://biorxiv.org",  # Read time outs
+    "https://zenodo.org/badge/*",  # avoid 403 error
+    "https://doi.org/*",  # avoid 403 error
 ]
 
 # -- Options for HTML output -------------------------------------------------

--- a/scripts/build_template_with_slurm.sh
+++ b/scripts/build_template_with_slurm.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+###
+# Wrapper script that is intended to be called from atlas-specific configuration slurm files
+# and calls modelbuild.sh under the hood.
+# Does some basic checks and prints basic logs to standard out.
+###
+
 # Start the timer
 start_time=$(date +%s)
 

--- a/scripts/build_template_with_slurm.sh
+++ b/scripts/build_template_with_slurm.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 
-###
-# Wrapper script that is intended to be called from atlas-specific configuration slurm files
-# and calls modelbuild.sh under the hood.
-# Does some basic checks and prints basic logs to standard out.
-###
-
 # Start the timer
 start_time=$(date +%s)
 
@@ -17,19 +11,26 @@ walltime_short="1:30:00"
 walltime_linear="03:00:00"
 walltime_nonlinear="40:00:00"
 toggle_dry_run="--dry-run"
+precision="--float" # default to single precision
+initial_target="first"
 
 
 # Function to display help message
 usage() {
-  echo "Usage: $0 --template-dir <path> [--average-type <string> --walltime-short <string> --walltime-linear <string> --walltime-nonlinear <string> --(no-)dry-run]"
+  echo "Usage: $0 --template-dir <path> [--average-type <string> --walltime-short <string> --walltime-linear <string> --walltime-nonlinear <string> --toggle-dry-run <string> --precision <string> --registration_metric <string> --initial_target <path>]"
   echo ""
   echo "Options:"
-  echo "  --template-dir <path>         Path to the atlas-forge template directory [REQUIRED]"
-  echo "  --average-type <string>       The type of average to use (default: mean)."
-  echo "  --walltime-short <string>     The max time required for "short" averaging/shape_update steps in HH:MM:SS (default: 1:30:00)."
-  echo "  --walltime-linear <string>    The max time required for linear registration steps in HH:MM:SS (default: 3:00:00)."
-  echo "  --walltime-nonlinear <string> The max time required for nonlinear registration steps in HH:MM:SS (default: 40:00:00)."
-  echo "  --(no-)dry-run                Toggle whether a dry run should be executed or not (default: --dry-run)."
+  echo "  --template-dir <path>          Path to the atlas-forge template directory [REQUIRED]"
+  echo "  --average-type <string>        The type of average to use (default: mean)."
+  echo "  --walltime-short <string>      The max time required for "short" averaging/shape_update steps in HH:MM:SS (default: 1:30:00)."
+  echo "  --walltime-linear <string>     The max time required for linear registration steps in HH:MM:SS (default: 3:00:00)."
+  echo "  --walltime-nonlinear <string>  The max time required for nonlinear registration steps in HH:MM:SS (default: 40:00:00)."
+  echo "  --toggle-dry-run <string>      Dry-run flag passed to modelbuild.sh (default: --dry-run)."
+  echo "                                 Allowed values: --dry-run or --no-dry-run."
+  echo "  --precision <string>           Precision flag passed to modelbuild.sh (default: --float; alternatively, pass empty string for double precision)."
+  echo "  --registration_metric <string> Registration metric override (default: Mattes; alternatively, pass '--fast' for cross-correlation)."
+  echo "  --initial_target <path>        Path to initial target (default: first)"
+  echo "  --help"
   exit 1
 }
 
@@ -67,6 +68,18 @@ while [[ $# -gt 0 ]]; do
       toggle_dry_run="$2"
       shift 2
       ;;
+    --precision)
+      precision="$2"
+      shift 2
+      ;;
+    --registration_metric)
+      registration_metric="$2"
+      shift 2
+      ;;
+    --initial_target)
+      initial_target="$2"
+      shift 2
+      ;;
     --help)
       usage
       ;;
@@ -76,6 +89,10 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+if [[ -n "$registration_metric" ]]; then
+  optional_args+=("${registration_metric}")
+fi
 
 echo "Finished parsing."
 
@@ -107,11 +124,13 @@ echo "Results will be written to ${template_dir}"
 # Execute the actual template building
 echo "Starting to build the template..."
 bash modelbuild.sh --output-dir "${template_dir}" \
-    --starting-target first \
-    --stages rigid,similarity,affine,nlin \
+    --starting-target "${initial_target}" \
+    --stages rigid,similariy,affine,nlin \
     --average-type "${average_type}" \
     --average-prog "${average_prog}" \
     --reuse-affines \
+    "${precision}" \
+    "${optional_args[@]}" \
     --walltime-short "${walltime_short}" \
     --walltime-linear "${walltime_linear}" \
     --walltime-nonlinear "${walltime_nonlinear}" \

--- a/tests/test_unit/test_preprocess.py
+++ b/tests/test_unit/test_preprocess.py
@@ -99,8 +99,8 @@ def test_preprocess_use_input(
 def test_preprocess(
     write_standardised_test_data: tuple[Path, Path], config_type: str
 ) -> None:
-    """Test that preprocess creates expected directories and files - both
-    with a config yaml file path as input OR a PreprocConfig object."""
+    """Test that preprocess creates expected directories and files - with
+    a config yaml file path as input, a PreprocConfig object OR None."""
     csv_path, config_path = write_standardised_test_data
 
     config: Path | PreprocConfig | None

--- a/tests/test_unit/test_preprocess.py
+++ b/tests/test_unit/test_preprocess.py
@@ -93,7 +93,7 @@ def test_preprocess_use_input(
 
 @pytest.mark.parametrize(
     "config_type",
-    ["config_file", "PreprocConfig object"],
+    ["config_file", "PreprocConfig object", "None"],
 )
 @pytest.mark.usefixtures("mock_fancylog_datetime")
 def test_preprocess(
@@ -103,13 +103,17 @@ def test_preprocess(
     with a config yaml file path as input OR a PreprocConfig object."""
     csv_path, config_path = write_standardised_test_data
 
-    config: Path | PreprocConfig
+    config: Path | PreprocConfig | None
     if config_type == "config_file":
         config = config_path
-    else:
+    elif config_type == "PreprocConfig object":
         with open(config_path) as f:
             config_yaml = yaml.safe_load(f)
         config = PreprocConfig.model_validate(config_yaml)
+    elif config_type == "None":
+        config = None
+    else:
+        raise ValueError("Testing with invalid config")
 
     preprocess(csv_path, config)
 


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**What does this PR do?**

* swaps the order of masking and brightness correction step
    * this is sensible because this way masks in the GUI are consistent.
* exposes three new parameters so they can be configured from the spawning slurm job
   * the precision (single or double). 
      * also sets `--float` (i.e. single precision) as the default behaviour (modelbuild.sh's default is double-precision, which seems overkill for our high-res data)
   * the registration metric (keeps the current Mattes metric as default)
   * the initial target
      * this is helpful because atlases created from asymmetric inputs and their LR-flips result in symmetric templates that are tilted like the initial target. This allows manually tilting a good sample to be almost perfectly aligned with the GUI and setting it as the initial target.


## References

Fixes #162 
Enables #163 

Companion PR to https://github.com/brainglobe/brainglobe-template-builder/pull/176 and https://github.com/brainglobe/brainglobe.github.io/pull/465

## How has this PR been tested?

By running the template building pipeline for an experimental, initial mixed-sex template for the zebrafinch.

## Is this a breaking change?

Yes, order of masking and brightness correction are swapped. This is so what you see in the GUI is what you get in the pipeline.

## Does this PR require an update to the documentation?

Yes.
Usage docs have been corrected, and expanded with changes here.
API docs for preprocess.py have been improved too.

## Checklist:

- [x] The code has been tested locally (manually, for one template)
- [n/a] Tests have been added to cover all new functionality (unit & integration)
- [in progress] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
