### PR TITLE
pass None for default preprocessing config

### DIFF
--- a/brainglobe_template_builder/preprocess.py
+++ b/brainglobe_template_builder/preprocess.py
@@ -18,7 +18,10 @@ from brainglobe_template_builder.utils.brightness import (
 )
 from brainglobe_template_builder.utils.cropping import crop_to_mask
 from brainglobe_template_builder.utils.masking import create_mask
-from brainglobe_template_builder.utils.preproc_config import PreprocConfig
+from brainglobe_template_builder.utils.preproc_config import (
+    MaskConfig,
+    PreprocConfig,
+)
 from brainglobe_template_builder.validate import validate_input_csv
 
 logger = logging.getLogger(__name__)
@@ -158,7 +161,9 @@ def _process_subject(
     }
 
 
-def preprocess(standardised_csv: Path, config: Path | PreprocConfig) -> None:
+def preprocess(
+    standardised_csv: Path, config: Path | PreprocConfig | None = None
+) -> None:
     """Process nifti files in ASR orientation to create output images +
     masks ready for template creation.
 
@@ -189,12 +194,19 @@ def preprocess(standardised_csv: Path, config: Path | PreprocConfig) -> None:
     standardised_csv : Path
         Standardised csv file path. One row per sample, each with a
         unique 'subject_id' - this is created via `standardise`.
-    config : Path | PreprocConfig
+    config : Path | PreprocConfig | None
         Config yaml file path, or PreprocConfig object. Contains settings for
-        pre-processing steps.
+        pre-processing steps. Defaults to None, which will use defaults.
     """
 
-    if isinstance(config, Path):
+    if not config:
+        # use default mask and padding, and default to outputting
+        # into sibling folder of `standardised/`
+        config = PreprocConfig(
+            output_dir=standardised_csv.parent.parent / "preprocessed",
+            mask=MaskConfig(),
+        )
+    elif isinstance(config, Path):
         with open(config) as f:
             config_yaml = yaml.safe_load(f)
         preproc_config = PreprocConfig.model_validate(config_yaml)

--- a/brainglobe_template_builder/preprocess.py
+++ b/brainglobe_template_builder/preprocess.py
@@ -202,8 +202,8 @@ def preprocess(
     if not config:
         # use default mask and padding, and default to outputting
         # into sibling folder of `standardised/`
-        config = PreprocConfig(
-            output_dir=standardised_csv.parent.parent / "preprocessed",
+        preproc_config = PreprocConfig(
+            output_dir=standardised_csv.parent.parent,
             mask=MaskConfig(),
         )
     elif isinstance(config, Path):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -90,6 +90,8 @@ exclude_patterns = [
 # during sphinx-build linkcheck
 linkcheck_ignore = [
     "https://opensource.org/license/*",  # to avoid odd 403 error
+    "https://zenodo.org/badge/*"  # to avoid 403 error
+    "https://doi.org"  # avoid 403 error
     "https://biorxiv.org",  # Read time outs
 ]
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -90,6 +90,7 @@ exclude_patterns = [
 # during sphinx-build linkcheck
 linkcheck_ignore = [
     "https://opensource.org/license/*",  # to avoid odd 403 error
+    "https://biorxiv.org",  # Read time outs
 ]
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -90,9 +90,8 @@ exclude_patterns = [
 # during sphinx-build linkcheck
 linkcheck_ignore = [
     "https://opensource.org/license/*",  # to avoid odd 403 error
-    "https://zenodo.org/badge/*"  # to avoid 403 error
-    "https://doi.org"  # avoid 403 error
-    "https://biorxiv.org",  # Read time outs
+    "https://zenodo.org/badge/*",  # avoid 403 error
+    "https://doi.org/*",  # avoid 403 error
 ]
 
 # -- Options for HTML output -------------------------------------------------

--- a/tests/test_unit/test_preprocess.py
+++ b/tests/test_unit/test_preprocess.py
@@ -99,8 +99,8 @@ def test_preprocess_use_input(
 def test_preprocess(
     write_standardised_test_data: tuple[Path, Path], config_type: str
 ) -> None:
-    """Test that preprocess creates expected directories and files - both
-    with a config yaml file path as input OR a PreprocConfig object."""
+    """Test that preprocess creates expected directories and files - with
+    a config yaml file path as input, a PreprocConfig object OR None."""
     csv_path, config_path = write_standardised_test_data
 
     config: Path | PreprocConfig | None

--- a/tests/test_unit/test_preprocess.py
+++ b/tests/test_unit/test_preprocess.py
@@ -93,7 +93,7 @@ def test_preprocess_use_input(
 
 @pytest.mark.parametrize(
     "config_type",
-    ["config_file", "PreprocConfig object"],
+    ["config_file", "PreprocConfig object", "None"],
 )
 @pytest.mark.usefixtures("mock_fancylog_datetime")
 def test_preprocess(
@@ -103,13 +103,17 @@ def test_preprocess(
     with a config yaml file path as input OR a PreprocConfig object."""
     csv_path, config_path = write_standardised_test_data
 
-    config: Path | PreprocConfig
+    config: Path | PreprocConfig | None
     if config_type == "config_file":
         config = config_path
-    else:
+    elif config_type == "PreprocConfig object":
         with open(config_path) as f:
             config_yaml = yaml.safe_load(f)
         config = PreprocConfig.model_validate(config_yaml)
+    elif config_type == "None":
+        config = None
+    else:
+        raise ValueError("Testing with invalid config")
 
     preprocess(csv_path, config)
 


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

Following group meeting discussion, we decided that it should be possible to run `preprocess` without needing any configuration object. This simplifies the code that people need to understand when working through a basic template-building guide.

**What does this PR do?**

Allows `preprocess` function to take a `None` config (now the default), and handles this by instantiating a default `PreprocConfig` and `MaskConfig` in the sibling folder of `standardised`.

Also ignores read time-outs to biorxiv for link checker.

## References

Related to internal discussion of https://github.com/brainglobe/brainglobe.github.io/pull/465

## How has this PR been tested?

Added a parameter to an existing unit test

## Is this a breaking change?

Nope

## Does this PR require an update to the documentation?

Docstrings updated.
Part of simplifying API to enable better documentation in https://github.com/brainglobe/brainglobe.github.io/pull/465

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
