### PR TITLE
Removes napari[all] from base dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ entry-points."napari.manifest".brainglobe-template-builder = "brainglobe_templat
 
 [project.optional-dependencies]
 dev = [
+    "brainglobe-template-builder[napari]",
     "pytest",
     "pytest-cov",
     "pytest-mock",
@@ -57,6 +58,7 @@ dev = [
     "pooch",
     "types-PyYAML"
 ]
+napari = ["napari[all]"]
 wingdisc = [
     'bioio',
     'bioio_czi',


### PR DESCRIPTION
Removes `napari[all]` from base dependencies and adds an optional `napari` group that requests `napari[all]`. Updates the dev optional group to install `brainglobe-template-builder[napari]` to ensure a complete install with dev.

I think the installation instructions in the README.md are still valid as users are requested to install the dev version of the locally cloned repo.