### PR TITLE
ci: migrate from tox to uv test action

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -16,13 +16,13 @@ jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
-      - uses: neuroinformatics-unit/actions/lint@v2
+      - uses: neuroinformatics-unit/actions/lint@34bedfdfd70c6010be02182c9ca37fae8a1fd99d # v3.0.0
 
   manifest:
     name: Check Manifest
     runs-on: ubuntu-latest
     steps:
-      - uses: neuroinformatics-unit/actions/check_manifest@v2
+      - uses: neuroinformatics-unit/actions/check_manifest@34bedfdfd70c6010be02182c9ca37fae8a1fd99d # v3.0.0
 
   test:
     needs: [linting, manifest]
@@ -42,52 +42,45 @@ jobs:
 
     steps:
       # checkout files, so the pooch cache can use hashFiles() in its key
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Cache test data to prevent repeated downloads
       - name: Cache pooch datasets
-        uses: actions/cache@v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: "~/.brainglobe/brainglobe-workflows/test-data"
           key: pooch-${{ runner.os }}-${{ hashFiles('./tests/fetch_test_data.py') }}
           enableCrossOsArchive: false
 
       # these libraries enable testing on Qt on linux
-      - uses: pyvista/setup-headless-display-action@v3
+      - name: Run tests
+        uses: neuroinformatics-unit/actions/test-uv@34bedfdfd70c6010be02182c9ca37fae8a1fd99d # v3.0.0
         with:
-          qt: true
+          python-version: "${{ matrix.python-version }}"
+          secret-codecov-token: ${{ secrets.CODECOV_TOKEN }}
+          install-extras: 'dev,napari'
+          use-headless: 'true'
 
-      # Run tests
-      - uses: neuroinformatics-unit/actions/test@v2
-        if: ${{ ! startsWith(matrix.os, 'windows-') }}
+      - name: Run tests against napari main
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        uses: neuroinformatics-unit/actions/test-uv@34bedfdfd70c6010be02182c9ca37fae8a1fd99d # v3.0.0
         with:
-          python-version: ${{ matrix.python-version }}
-
-      # Run tests on napari main if this is a scheduled run
-      - name: Run tests on napari main
-        if: github.event_name == 'schedule'
-        uses: neuroinformatics-unit/actions/test@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-          tox-args: '-e napari-dev'
-
-      - name: Set up Python ${{ matrix.python-version }} on Windows
-        if: startsWith(matrix.os, 'windows-')
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "${{ matrix.python-version }}"
+          secret-codecov-token: ${{ secrets.CODECOV_TOKEN }}
+          install-extras: 'dev,napari'
+          use-headless: 'true'
+          install-main-branch: 'napari/napari'
 
       - name: Install and run tox on Windows
         if: startsWith(matrix.os, 'windows-')
         shell: cmd
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install tox tox-gh-actions
+          uv pip install tox tox-gh-actions
           tox
 
       - name: Notify slack on scheduled failure
         if: failure() && github.event_name == 'schedule'
-        uses: ravsamhq/notify-slack-action@v2
+        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v2.5.0
         with:
           status: ${{ job.status }} # required
           notify_when: 'failure'
@@ -101,7 +94,7 @@ jobs:
     if: github.event_name == 'push' && github.ref_type == 'tag'
     runs-on: ubuntu-latest
     steps:
-    - uses: neuroinformatics-unit/actions/build_sdist_wheels@v2
+    - uses: neuroinformatics-unit/actions/build_sdist_wheels@34bedfdfd70c6010be02182c9ca37fae8a1fd99d # v3.0.0
 
 
   upload_all:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ dev = [
     "pytest-mock",
     "pytest-qt",
     "coverage",
-    "tox",
     "black",
     "mypy",
     "pre-commit",
@@ -76,9 +75,8 @@ include-package-data = true
 include = ["brainglobe_template_builder*"]
 exclude = ["tests", "docs*"]
 
-
 [tool.pytest.ini_options]
-addopts = "--cov=brainglobe_template_builder"
+addopts = "--cov=brainglobe_template_builder --cov-report=xml --color=yes -vv"
 
 [tool.black]
 target-version = ['py311', 'py312', 'py313']
@@ -108,31 +106,3 @@ line-length = 79
 exclude = ["__init__.py", "build", ".eggs", "scripts"]
 select = ["I", "E", "F"]
 fix = true
-
-[tool.tox]
-legacy_tox_ini = """
-[tox]
-envlist = py{311,312,313}, napari-dev
-isolated_build = True
-
-[gh-actions]
-python =
-    3.11: py311
-    3.12: py312
-    3.13: py313
-
-[testenv]
-extras =
-    dev
-commands =
-    pytest -v --color=yes --cov=brainglobe_template_builder --cov-report=xml
-passenv =
-    CI
-    GITHUB_ACTIONS
-    DISPLAY
-    XAUTHORITY
-    NUMPY_EXPERIMENTAL_ARRAY_FUNCTION
-    PYVISTA_OFF_SCREEN
-deps =
-    napari-dev: git+https://github.com/napari/napari
-"""


### PR DESCRIPTION
Migrate CI from `neuroinformatics-unit/actions/test@v2` (tox) to `neuroinformatics-unit/actions/test-uv@main` (pure uv).