### PR TITLE
Update dependencies in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "brainglobe-atlasapi>=2.0.7",
     "napari-itk-io",
     "loguru",
-    "antspyx",
+    "matplotlib",
     "qt-niu",
     "pydantic",
     "simpleitk",


### PR DESCRIPTION
Replaced 'antspyx' with 'matplotlib' in dependencies.
I don't think we use ANTs in the preprocessing part anymore, but we do need `matplotlib` for the QC plots.
